### PR TITLE
Remove insider commentary and status markers from all documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Each pattern includes:
 
 ---
 
-## The 6 Patterns (All Complete ✅)
+## The 6 Patterns
 
 ### Pattern 1: Onboarding & First-Run Experience
 **Problem:** 15-20 minute setup, key management overwhelming
@@ -144,11 +144,11 @@ Full framework with examples in **[Introduction](introduction.md#the-validation-
 ## Research Foundation
 
 This study synthesizes:
-- ✅ Academic HCI research on social media UX, onboarding, feed algorithms
-- ✅ Industry design systems (Apple HIG, Material Design)
-- ✅ Nostr-specific data (retention metrics from nostr.band, user complaints, GitHub issues)
-- ✅ Mainstream app case studies (TikTok, Instagram, Bluesky, Discord)
-- ✅ 100+ verified sources with URLs (strict citation policy)
+- Academic HCI research on social media UX, onboarding, feed algorithms
+- Industry design systems (Apple HIG, Material Design)
+- Nostr-specific data (retention metrics from nostr.band, user complaints, GitHub issues)
+- Mainstream app case studies (TikTok, Instagram, Bluesky, Discord)
+- 100+ verified sources with URLs (strict citation policy)
 
 **Content balance:** 70% universal principles (applicable to any social app) + 30% Nostr-specific considerations (relays, keys, decentralization)
 
@@ -164,7 +164,7 @@ nostr-ux-research/
 ├── introduction.md                     # Why this exists, Validation Framework, where to start
 ├── quick-reference.md                  # TL;DR summaries of all 6 patterns
 ├── OUTLINE.md                          # Original study structure
-├── patterns/                           # Detailed pattern documentation (all complete ✅)
+├── patterns/                           # Detailed pattern documentation
 │   ├── 01-onboarding.md                # ~1200 lines, 20+ citations
 │   ├── 02-content-discovery.md         # ~1900 lines, 67+ citations
 │   ├── 03-core-interactions.md         # ~1500 lines, 30+ citations

--- a/appendices/references.md
+++ b/appendices/references.md
@@ -1103,5 +1103,3 @@ Yeager, Shawn. "Nostr UX Research Study: Design Patterns for Consumer Applicatio
 ---
 
 *Last updated: November 2025*
-
-**Note:** This is a living document. Citations are added as patterns are developed. Placeholders marked with [To be researched] will be filled during the writing process.

--- a/patterns/01-onboarding.md
+++ b/patterns/01-onboarding.md
@@ -1,7 +1,5 @@
 # Pattern 1: Onboarding & First-Run Experience
 
-**Status:** ✅ Complete with citations
-
 ---
 
 ## Problem Statement
@@ -975,4 +973,3 @@ Interest-based follow suggestions, pre-populated feed
 ---
 
 *Last updated: November 2025*
-*Status: Complete with citations - All major claims backed by research and user feedback*

--- a/patterns/02-content-discovery.md
+++ b/patterns/02-content-discovery.md
@@ -1,6 +1,5 @@
 # Pattern 2: Content Discovery & Feed Quality
 
-**Status:** ✅ Complete with 2024-2025 citations
 **Last Updated:** November 2025
 
 ---

--- a/patterns/03-core-interactions.md
+++ b/patterns/03-core-interactions.md
@@ -1,6 +1,5 @@
 # Pattern 3: Core Interaction Loops
 
-**Status:** ✅ Complete
 **Last Updated:** November 7, 2025
 
 ---

--- a/patterns/04-performance.md
+++ b/patterns/04-performance.md
@@ -1,6 +1,5 @@
 # Pattern 4: Performance & Perceived Speed
 
-**Status:** ✅ Complete
 **Last Updated:** November 7, 2025
 **Research Currency:** All sources from 2024-2025
 

--- a/patterns/05-progressive-complexity.md
+++ b/patterns/05-progressive-complexity.md
@@ -1,6 +1,5 @@
 # Pattern 5: Progressive Complexity
 
-**Status:** ✅ Complete
 **Last Updated:** November 8, 2025
 **Research Currency:** All sources from 2024-2025
 

--- a/patterns/06-cross-client-consistency.md
+++ b/patterns/06-cross-client-consistency.md
@@ -1,6 +1,5 @@
 # Pattern 6: Cross-Client Consistency & Data Integrity
 
-**Status:** ✅ Complete
 **Last Updated:** November 8, 2025
 **Research Currency:** All sources from 2024-2025
 
@@ -1162,5 +1161,3 @@ User's posts disappear with no explanation
 ---
 
 **Previous Pattern:** [Pattern 5: Progressive Complexity](05-progressive-complexity.md)
-
-**Status:** This completes all 6 critical patterns for Nostr UX.


### PR DESCRIPTION
Cleaned up development/project management commentary that shouldn't be in public-facing documents:
- Removed "All Complete ✅" markers from README.md
- Removed "Status: ✅ Complete" lines from all 6 pattern documents
- Removed completion note from pattern 06
- Removed development process note from references.md

Preserved reader-facing content:
- Last Updated metadata
- Research Currency notes
- Validation checklists
- UI examples with status symbols