### PR TITLE
Add Hugo static site for GitHub Pages deployment

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,0 +1,73 @@
+name: Deploy Hugo site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.121.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --gc \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Hugo build output
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local development
+.hugo_build.lock
+node_modules/

--- a/HUGO_SITE.md
+++ b/HUGO_SITE.md
@@ -1,0 +1,250 @@
+# Hugo Site Documentation
+
+This repository includes a Hugo static site for the Nostr UX Research Study, designed to be deployed to GitHub Pages.
+
+## Architecture
+
+**Static Site Generator:** Hugo (v0.121.0+)
+**Theme:** Custom clean/minimal theme (`themes/nostr-ux/`)
+**Deployment:** GitHub Actions → GitHub Pages
+**Analytics:** Plausible.io
+**Search:** Lunr.js (client-side)
+
+## Directory Structure
+
+```
+nostr-ux-research/
+├── hugo.toml                    # Hugo configuration
+├── content/                     # Hugo-specific content
+│   ├── _index.md               # Homepage content
+│   ├── patterns/_index.md      # Pattern library index
+│   └── start/_index.md         # Get Started page
+├── patterns/                    # Pattern markdown files (mounted to content/patterns/)
+│   ├── 01-onboarding.md        # With YAML front matter
+│   ├── 02-content-discovery.md
+│   └── ... (all 6 patterns)
+├── appendices/                  # Resources (mounted to content/resources/)
+├── quick-reference.md           # Mounted to content/
+├── themes/nostr-ux/            # Custom theme
+│   ├── layouts/                 # HTML templates
+│   │   ├── _default/
+│   │   │   ├── baseof.html     # Base template
+│   │   │   ├── list.html       # Section pages
+│   │   │   ├── single.html     # Individual pages
+│   │   │   └── index.json      # Search index
+│   │   ├── index.html          # Homepage template
+│   │   └── partials/
+│   │       ├── header.html
+│   │       └── footer.html
+│   └── static/                  # CSS, JS, images
+│       ├── css/main.css        # Clean/minimal styling
+│       └── js/search.js        # Search functionality
+└── .github/workflows/hugo.yml   # CI/CD pipeline
+
+## Content Organization
+
+Hugo uses "mounts" to map existing markdown files:
+- `patterns/` → `content/patterns/` (the 6 pattern documents)
+- `appendices/` → `content/resources/` (references, methodology)
+- `quick-reference.md` → `content/quick-reference.md`
+
+This allows the original markdown files to remain readable on GitHub while being processed by Hugo for the website.
+
+## Front Matter
+
+All pattern files now include YAML front matter:
+
+```yaml
+---
+title: "Onboarding & First-Run Experience"
+patternNumber: 1
+problem: "15-20 minute setup, key management overwhelming"
+impact: "Users abandon before reaching value"
+solution: "Minimize time-to-first-value, defer complexity"
+showToc: true
+weight: 1
+---
+```
+
+This metadata powers:
+- Homepage pattern cards
+- Pattern list views
+- Search indexing
+- Navigation ordering
+
+## Local Development
+
+### Prerequisites
+- Hugo Extended v0.121.0+ ([install guide](https://gohugo.io/installation/))
+- Git
+
+### Run locally
+```bash
+cd nostr-ux-research
+hugo server -D
+```
+
+Visit: http://localhost:1313/nostr-ux-research/
+
+### Build for production
+```bash
+hugo --gc --minify
+```
+
+Output in `public/` directory.
+
+## Deployment
+
+**Automatic via GitHub Actions:**
+1. Push to `master` branch
+2. GitHub Actions workflow runs (`.github/workflows/hugo.yml`)
+3. Hugo builds the site
+4. Deploys to GitHub Pages
+
+**Manual deployment:**
+Not recommended. Use the automated workflow.
+
+## Features
+
+### Homepage
+- Hero section with clear value proposition
+- Problem statement with statistics
+- Pattern preview cards (auto-generated from front matter)
+- Validation framework overview
+- Target audience callout
+
+### Pattern Pages
+- Sticky table of contents
+- Syntax-highlighted code examples
+- Previous/Next navigation
+- Clean typography optimized for reading
+
+### Search
+- Client-side search powered by Lunr.js
+- Keyboard shortcut to open (click search icon)
+- Searches titles, content, and tags
+- Results show relevant excerpts
+
+### Mobile Responsive
+- Mobile-first CSS
+- Readable on all screen sizes
+- Touch-optimized navigation
+
+## Analytics
+
+Configured for Plausible.io (privacy-friendly analytics):
+- Domain: `shawnyeager.github.io`
+- Script: `https://plausible.io/js/script.js`
+- No cookies, GDPR compliant
+
+To set up:
+1. Create account at plausible.io
+2. Add site: `shawnyeager.github.io/nostr-ux-research`
+3. Verify tracking is working after deployment
+
+## Design Decisions
+
+**Clean/Minimal Style:**
+- Inspired by Stripe/Linear documentation
+- Focus on readability and content
+- Minimal distractions
+- Professional yet approachable
+
+**Mobile-First:**
+- Base styles for mobile
+- Progressive enhancement for larger screens
+- Touch-friendly tap targets
+
+**Performance:**
+- Minimal JavaScript (only search)
+- Static generation (fast loads)
+- Lazy loading for images (if added later)
+
+## Customization
+
+### Colors
+Edit CSS variables in `themes/nostr-ux/static/css/main.css`:
+```css
+:root {
+  --color-primary: #2563eb;
+  --color-text: #1e293b;
+  /* ... */
+}
+```
+
+### Navigation
+Edit menu in `hugo.toml`:
+```toml
+[[menu.main]]
+  name = 'Patterns'
+  url = '/patterns/'
+  weight = 3
+```
+
+### Analytics
+Update in `hugo.toml`:
+```toml
+[params]
+  plausibleDomain = 'your-domain.com'
+```
+
+## Future Enhancements
+
+Marked as "for later" but easy to add:
+
+1. **Interactive code examples** - Add CodePen embeds or live demos
+2. **Mobile app previews** - Screenshot galleries or video demos
+3. **Nostr integration** - Comments via Nostr, zaps for patterns
+4. **Dark mode** - CSS variables make this straightforward
+5. **Pattern filtering** - Filter by severity, implementation effort
+
+## Troubleshooting
+
+**Hugo build fails:**
+- Check Hugo version: `hugo version` (need v0.121.0+)
+- Use extended version (required for Sass)
+
+**Search not working:**
+- Ensure `index.json` is being generated
+- Check browser console for errors
+- Verify Lunr.js is loading
+
+**Images not showing:**
+- Place in `static/images/` or `themes/nostr-ux/static/images/`
+- Reference as `/nostr-ux-research/images/filename.png`
+
+**GitHub Pages 404:**
+- Verify repository settings → Pages → Source is "gh-pages" branch
+- Check Actions tab for deployment status
+- Ensure `baseURL` in `hugo.toml` matches your GitHub Pages URL
+
+## Maintenance
+
+**Adding a new pattern:**
+1. Create markdown file in `patterns/`
+2. Add YAML front matter (copy from existing pattern)
+3. Set appropriate `patternNumber` and `weight`
+4. Content will automatically appear in navigation and search
+
+**Updating existing content:**
+- Edit markdown files directly in `patterns/`, `appendices/`, etc.
+- Hugo's mounts will pick up changes automatically
+- Push to master to deploy
+
+**Theme updates:**
+- Edit layouts in `themes/nostr-ux/layouts/`
+- Edit CSS in `themes/nostr-ux/static/css/main.css`
+- Test locally before pushing
+
+## Resources
+
+- [Hugo Documentation](https://gohugo.io/documentation/)
+- [Hugo Mounts](https://gohugo.io/hugo-modules/configuration/#module-config-mounts)
+- [Lunr.js Documentation](https://lunrjs.com/)
+- [Plausible Analytics](https://plausible.io/docs)
+
+---
+
+**Questions or issues?** Open an issue on GitHub.
+
+Last updated: November 2025

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Nostr UX Research Study"
+description: "Design patterns for building consumer Nostr applications with great UX"
+---
+
+This content is rendered by the homepage template.

--- a/content/patterns/_index.md
+++ b/content/patterns/_index.md
@@ -1,0 +1,14 @@
+---
+title: "The 6 Critical Patterns"
+description: "Research-backed solutions to the highest-impact UX problems in Nostr applications"
+---
+
+These six patterns address the most critical UX problems facing Nostr applications today, based on extensive research of user complaints, retention data, and mainstream app best practices.
+
+Each pattern includes:
+- **Problem Statement** backed by research
+- **Universal Principles** (70% - applicable to any social app)
+- **Nostr-Specific Considerations** (30%)
+- **Pattern Library** with concrete examples
+- **Anti-Patterns** to avoid
+- **Validation Checklist** to measure success

--- a/content/start/_index.md
+++ b/content/start/_index.md
@@ -1,0 +1,109 @@
+---
+title: "Get Started"
+description: "Where to begin with improving your Nostr app's UX"
+---
+
+## Executive Overview
+
+**The Problem:** Nostr is struggling with user retention. 30-day retention trends toward 0%, DAU is stuck at 10-12k trusted pubkeys, and users need 5-6 different clients to work around bugs. The root cause isn't the protocol—it's UX.
+
+**The Solution:** Six research-backed patterns that address the highest-impact problems:
+
+1. **Onboarding** - Get users to value in under 2 minutes
+2. **Content Discovery** - Solve the empty feed problem
+3. **Core Interactions** - Make basic actions reliable
+4. **Performance** - Feel fast even when slow
+5. **Progressive Complexity** - Hide advanced features from beginners
+6. **Cross-Client Consistency** - Don't lose data when switching apps
+
+**Who This Is For:**
+- Nostr developers building consumer apps
+- Product designers working on Nostr clients
+- Mainstream developers evaluating Nostr
+
+**Core Principle:** Great UX is the gateway to the protocol's power. Ship working experiences, then add features.
+
+---
+
+## Where to Start
+
+### If you have 5 minutes
+Read the [Quick Reference](/quick-reference/) for TL;DR summaries of all 6 patterns.
+
+### If you have 30 minutes
+Pick the pattern that matches your biggest pain point:
+- **Users abandon during signup?** → [Pattern 1: Onboarding](/patterns/01-onboarding/)
+- **Empty feeds after signup?** → [Pattern 2: Content Discovery](/patterns/02-content-discovery/)
+- **Posts disappearing?** → [Pattern 3: Core Interactions](/patterns/03-core-interactions/)
+- **App feels slow/crashy?** → [Pattern 4: Performance](/patterns/04-performance/)
+- **Users overwhelmed by settings?** → [Pattern 5: Progressive Complexity](/patterns/05-progressive-complexity/)
+- **Data loss when switching clients?** → [Pattern 6: Cross-Client Consistency](/patterns/06-cross-client-consistency/)
+
+### If you're building from scratch
+Read patterns in order (1-6). Each builds on principles from earlier patterns.
+
+### If you want evidence
+Check the [Research Methodology](/resources/methodology/) and [References](/resources/references/) to see the 100+ sources backing these patterns.
+
+---
+
+## The Validation Framework
+
+Before building any feature, ask these three questions:
+
+1. **Does this help users accomplish their core goal?** (seeing content, connecting with people)
+2. **Have we validated this solves a real problem?** (data, user feedback, research - not hunches)
+3. **Can we measure if it's working?** (leading indicators, lagging indicators, qualitative signals)
+
+If you can't answer "yes" to all three, reconsider whether this feature should be built now.
+
+**Learn more:** Full framework with examples in the [Introduction](/introduction/).
+
+---
+
+## Quick Wins
+
+Here are high-impact, low-effort improvements you can ship this week:
+
+**Onboarding:**
+- Add guest/browse mode (see content before account creation)
+- Reduce required fields to just username
+- Auto-select relays, don't make users choose
+
+**Content Discovery:**
+- Show trending/popular content on empty feeds
+- Add basic search functionality
+- Create starter packs of accounts to follow
+
+**Core Interactions:**
+- Implement optimistic UI for likes/reposts
+- Show clear error messages (not relay URLs)
+- Add retry logic for failed actions
+
+**Performance:**
+- Add skeleton screens while loading
+- Cache profile data locally
+- Lazy load images
+
+**Progressive Complexity:**
+- Move relay settings to Advanced
+- Hide signer setup from onboarding
+- Use plain language, not protocol jargon
+
+**Cross-Client Consistency:**
+- Write to 3+ relays for critical data
+- Verify successful writes before confirming
+- Add sync status indicators
+
+---
+
+## Next Steps
+
+1. **Browse the patterns** that match your current priorities
+2. **Join the discussion** on Nostr (search for #NostrUX)
+3. **Share feedback** by opening issues on [GitHub](https://github.com/shawnyeager/nostr-ux-research)
+4. **Measure your improvements** using the validation checklists in each pattern
+
+---
+
+*Remember: You don't have to implement everything at once. Pick one pattern, validate it works, then move to the next.*

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,74 @@
+baseURL = 'https://shawnyeager.github.io/nostr-ux-research/'
+languageCode = 'en-us'
+title = 'Nostr UX Research Study'
+theme = 'nostr-ux'
+
+[params]
+  description = 'Design patterns for building consumer Nostr applications with great UX'
+  author = 'Shawn Yeager'
+
+  # Plausible.io analytics
+  plausibleDomain = 'shawnyeager.github.io'
+  plausibleScript = 'https://plausible.io/js/script.js'
+
+[menu]
+  [[menu.main]]
+    name = 'Home'
+    url = '/'
+    weight = 1
+
+  [[menu.main]]
+    name = 'Get Started'
+    url = '/start/'
+    weight = 2
+
+  [[menu.main]]
+    name = 'Patterns'
+    url = '/patterns/'
+    weight = 3
+
+  [[menu.main]]
+    name = 'Quick Reference'
+    url = '/quick-reference/'
+    weight = 4
+
+  [[menu.main]]
+    name = 'Resources'
+    url = '/resources/'
+    weight = 5
+
+[markup]
+  [markup.highlight]
+    style = 'github'
+    lineNos = true
+    lineNumbersInTable = true
+
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+
+[outputs]
+  home = ['HTML', 'JSON']
+  section = ['HTML']
+  page = ['HTML']
+
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+
+  [[module.mounts]]
+    source = "patterns"
+    target = "content/patterns"
+
+  [[module.mounts]]
+    source = "appendices"
+    target = "content/resources"
+
+  [[module.mounts]]
+    source = "static"
+    target = "static"
+
+  [[module.mounts]]
+    source = "themes/nostr-ux/static"
+    target = "static"

--- a/patterns/01-onboarding.md
+++ b/patterns/01-onboarding.md
@@ -1,5 +1,11 @@
-# Pattern 1: Onboarding & First-Run Experience
-
+---
+title: "Onboarding & First-Run Experience"
+patternNumber: 1
+problem: "15-20 minute setup, key management overwhelming"
+impact: "Users abandon before reaching value"
+solution: "Minimize time-to-first-value, defer complexity, browse-first approach"
+showToc: true
+weight: 1
 ---
 
 ## Problem Statement

--- a/patterns/02-content-discovery.md
+++ b/patterns/02-content-discovery.md
@@ -1,7 +1,12 @@
-# Pattern 2: Content Discovery & Feed Quality
-
-**Last Updated:** November 2025
-
+---
+title: "Content Discovery & Feed Quality"
+patternNumber: 2
+problem: "Empty feeds, Traditional apps win by having better content selection"
+impact: "Users bounce because feed is boring"
+solution: "Smart defaults, starter packs, algorithmic discovery, search that works"
+showToc: true
+weight: 2
+lastUpdated: "November 2025"
 ---
 
 ## Table of Contents

--- a/patterns/03-core-interactions.md
+++ b/patterns/03-core-interactions.md
@@ -1,7 +1,12 @@
-# Pattern 3: Core Interaction Loops
-
-**Last Updated:** November 7, 2025
-
+---
+title: "Core Interaction Loops"
+patternNumber: 3
+problem: "Posts disappear, notifications missing, unreliable actions"
+impact: "Users lose trust, abandon platform"
+solution: "Optimistic UI, instant feedback, error recovery, reliability first"
+showToc: true
+weight: 3
+lastUpdated: "November 7, 2025"
 ---
 
 ## Table of Contents

--- a/patterns/04-performance.md
+++ b/patterns/04-performance.md
@@ -1,8 +1,13 @@
-# Pattern 4: Performance & Perceived Speed
-
-**Last Updated:** November 7, 2025
-**Research Currency:** All sources from 2024-2025
-
+---
+title: "Performance & Perceived Speed"
+patternNumber: 4
+problem: "Apps hang/buffer, crashes, slow loading"
+impact: "Users perceive apps as unreliable"
+solution: "Skeleton screens, optimistic UI, lazy loading, caching strategies"
+showToc: true
+weight: 4
+lastUpdated: "November 7, 2025"
+researchCurrency: "All sources from 2024-2025"
 ---
 
 ## Table of Contents

--- a/patterns/05-progressive-complexity.md
+++ b/patterns/05-progressive-complexity.md
@@ -1,8 +1,13 @@
-# Pattern 5: Progressive Complexity
-
-**Last Updated:** November 8, 2025
-**Research Currency:** All sources from 2024-2025
-
+---
+title: "Progressive Complexity"
+patternNumber: 5
+problem: "Relay management, key signers, NIPs exposed to all users"
+impact: "Overwhelming, users leave"
+solution: "80/20 rule, smart defaults work for most, hide advanced settings"
+showToc: true
+weight: 5
+lastUpdated: "November 8, 2025"
+researchCurrency: "All sources from 2024-2025"
 ---
 
 ## Table of Contents

--- a/patterns/06-cross-client-consistency.md
+++ b/patterns/06-cross-client-consistency.md
@@ -1,8 +1,13 @@
-# Pattern 6: Cross-Client Consistency & Data Integrity
-
-**Last Updated:** November 8, 2025
-**Research Currency:** All sources from 2024-2025
-
+---
+title: "Cross-Client Consistency & Data Integrity"
+patternNumber: 6
+problem: "Lost all followers when switching clients"
+impact: "Users don't trust the platform"
+solution: "Multi-relay write strategy, sync verification, conflict resolution"
+showToc: true
+weight: 6
+lastUpdated: "November 8, 2025"
+researchCurrency: "All sources from 2024-2025"
 ---
 
 ## Table of Contents

--- a/quick-reference.md
+++ b/quick-reference.md
@@ -1,6 +1,10 @@
-# Quick Reference Guide
-
-**TL;DR summaries of all 6 UX patterns for Nostr clients.**
+---
+title: "Quick Reference Guide"
+description: "TL;DR summaries of all 6 UX patterns for Nostr clients"
+menu:
+  main:
+    weight: 4
+---
 
 Scan this guide in ~10 minutes to understand the critical issues. Then deep-dive the patterns most relevant to your work.
 

--- a/themes/nostr-ux/layouts/_default/baseof.html
+++ b/themes/nostr-ux/layouts/_default/baseof.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang }}">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ .Description | default .Site.Params.description }}">
+  <title>{{ block "title" . }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+
+  <link rel="stylesheet" href="{{ "css/main.css" | relURL }}">
+
+  {{ if .Site.Params.plausibleDomain }}
+  <script defer data-domain="{{ .Site.Params.plausibleDomain }}" src="{{ .Site.Params.plausibleScript }}"></script>
+  {{ end }}
+</head>
+<body>
+  {{ partial "header.html" . }}
+
+  <main>
+    {{ block "main" . }}{{ end }}
+  </main>
+
+  {{ partial "footer.html" . }}
+
+  <script src="https://unpkg.com/lunr/lunr.js"></script>
+  <script src="{{ "js/search.js" | relURL }}"></script>
+  {{ block "scripts" . }}{{ end }}
+</body>
+</html>

--- a/themes/nostr-ux/layouts/_default/index.json
+++ b/themes/nostr-ux/layouts/_default/index.json
@@ -1,0 +1,21 @@
+{{- $pages := where .Site.RegularPages "Type" "in" (slice "patterns" "resources" "page") -}}
+{{- $searchData := slice -}}
+{{- range $pages -}}
+  {{- $content := .Plain | htmlUnescape -}}
+  {{- $content = replaceRE "[\\n\\r]+" " " $content -}}
+  {{- $content = replaceRE "\\s+" " " $content -}}
+  {{- $tags := slice -}}
+  {{- with .Params.patternNumber -}}
+    {{- $tags = $tags | append (printf "Pattern %v" .) -}}
+  {{- end -}}
+  {{- with .Params.tags -}}
+    {{- $tags = $tags | append . -}}
+  {{- end -}}
+  {{- $searchData = $searchData | append (dict
+    "url" .RelPermalink
+    "title" .Title
+    "content" $content
+    "tags" (delimit $tags " ")
+  ) -}}
+{{- end -}}
+{{- $searchData | jsonify -}}

--- a/themes/nostr-ux/layouts/_default/list.html
+++ b/themes/nostr-ux/layouts/_default/list.html
@@ -1,0 +1,42 @@
+{{ define "main" }}
+<div class="page-header">
+  <div class="container">
+    <h1>{{ .Title }}</h1>
+    {{ with .Params.description }}
+    <p class="page-description">{{ . }}</p>
+    {{ end }}
+  </div>
+</div>
+
+<div class="container">
+  <div class="content">
+    {{ .Content }}
+
+    {{ if eq .Section "patterns" }}
+    <div class="pattern-list">
+      {{ range .Pages.ByParam "patternNumber" }}
+      <article class="pattern-list-item">
+        <div class="pattern-meta">
+          <span class="pattern-number">Pattern {{ .Params.patternNumber }}</span>
+        </div>
+        <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+        {{ with .Params.problem }}<p class="meta-item"><strong>Problem:</strong> {{ . }}</p>{{ end }}
+        {{ with .Params.impact }}<p class="meta-item"><strong>Impact:</strong> {{ . }}</p>{{ end }}
+        {{ with .Params.solution }}<p class="meta-item"><strong>Solution:</strong> {{ . }}</p>{{ end }}
+        <a href="{{ .RelPermalink }}" class="read-more">Read Full Pattern →</a>
+      </article>
+      {{ end }}
+    </div>
+    {{ else }}
+    <div class="page-list">
+      {{ range .Pages }}
+      <article class="page-list-item">
+        <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+        {{ with .Description }}<p>{{ . }}</p>{{ end }}
+      </article>
+      {{ end }}
+    </div>
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/themes/nostr-ux/layouts/_default/single.html
+++ b/themes/nostr-ux/layouts/_default/single.html
@@ -1,0 +1,49 @@
+{{ define "main" }}
+<article class="single-page">
+  <div class="page-header">
+    <div class="container">
+      {{ if .Params.patternNumber }}
+      <div class="pattern-badge">Pattern {{ .Params.patternNumber }}</div>
+      {{ end }}
+      <h1>{{ .Title }}</h1>
+      {{ with .Params.lastUpdated }}
+      <p class="meta">Last Updated: {{ . }}</p>
+      {{ end }}
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="content-wrapper">
+      {{ if .Params.showToc }}
+      <aside class="toc">
+        <h3>Table of Contents</h3>
+        {{ .TableOfContents }}
+      </aside>
+      {{ end }}
+
+      <div class="content">
+        {{ .Content }}
+      </div>
+    </div>
+  </div>
+
+  {{ if or .PrevInSection .NextInSection }}
+  <nav class="page-navigation">
+    <div class="container">
+      {{ with .PrevInSection }}
+      <a href="{{ .RelPermalink }}" class="nav-prev">
+        <span class="nav-label">← Previous</span>
+        <span class="nav-title">{{ .Title }}</span>
+      </a>
+      {{ end }}
+      {{ with .NextInSection }}
+      <a href="{{ .RelPermalink }}" class="nav-next">
+        <span class="nav-label">Next →</span>
+        <span class="nav-title">{{ .Title }}</span>
+      </a>
+      {{ end }}
+    </div>
+  </nav>
+  {{ end }}
+</article>
+{{ end }}

--- a/themes/nostr-ux/layouts/index.html
+++ b/themes/nostr-ux/layouts/index.html
@@ -1,0 +1,97 @@
+{{ define "main" }}
+<div class="hero">
+  <div class="container">
+    <h1>Design Patterns for Nostr UX</h1>
+    <p class="hero-subtitle">Research-backed patterns to build consumer Nostr applications that people actually want to use</p>
+    <div class="hero-cta">
+      <a href="{{ "/start/" | relURL }}" class="btn btn-primary">Get Started</a>
+      <a href="{{ "/patterns/" | relURL }}" class="btn btn-secondary">Browse Patterns</a>
+    </div>
+  </div>
+</div>
+
+<section class="problem-section">
+  <div class="container">
+    <h2>The Problem</h2>
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-number">0%</div>
+        <div class="stat-label">30-day retention for recent cohorts</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">15-20 min</div>
+        <div class="stat-label">Onboarding time drives abandonment</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">5-6</div>
+        <div class="stat-label">Clients needed to work around bugs</div>
+      </div>
+    </div>
+    <p class="section-lead">Users are abandoning Nostr apps because core UX is broken. Feature bloat and protocol complexity are overwhelming users before they reach value.</p>
+  </div>
+</section>
+
+<section class="patterns-preview">
+  <div class="container">
+    <h2>The 6 Critical Patterns</h2>
+    <p class="section-lead">Research-backed solutions to the highest-impact UX problems in Nostr applications</p>
+
+    <div class="pattern-grid">
+      {{ range where .Site.RegularPages "Section" "patterns" }}
+      <article class="pattern-card">
+        <div class="pattern-number">{{ .Params.patternNumber }}</div>
+        <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+        {{ with .Params.problem }}<p class="pattern-problem"><strong>Problem:</strong> {{ . }}</p>{{ end }}
+        {{ with .Params.impact }}<p class="pattern-impact"><strong>Impact:</strong> {{ . }}</p>{{ end }}
+        {{ with .Params.solution }}<p class="pattern-solution"><strong>Solution:</strong> {{ . }}</p>{{ end }}
+        <a href="{{ .RelPermalink }}" class="pattern-link">Read Pattern →</a>
+      </article>
+      {{ end }}
+    </div>
+
+    <div class="cta-block">
+      <a href="{{ "/patterns/" | relURL }}" class="btn btn-large">View All Patterns</a>
+    </div>
+  </div>
+</section>
+
+<section class="validation-framework">
+  <div class="container">
+    <h2>The Validation Framework</h2>
+    <p class="section-lead">Before building any feature, ask these three questions:</p>
+    <ol class="framework-questions">
+      <li><strong>Does this help users accomplish their core goal?</strong> (seeing content, connecting with people)</li>
+      <li><strong>Have we validated this solves a real problem?</strong> (data, user feedback, research - not hunches)</li>
+      <li><strong>Can we measure if it's working?</strong> (leading indicators, lagging indicators, qualitative signals)</li>
+    </ol>
+    <p class="framework-principle"><strong>Core principle:</strong> Great UX is the gateway to the protocol's power.</p>
+  </div>
+</section>
+
+<section class="audience-section">
+  <div class="container">
+    <h2>Who This Is For</h2>
+    <div class="audience-grid">
+      <div class="audience-card">
+        <h3>Nostr Developers</h3>
+        <p>Building consumer social apps (mobile, web, desktop) and want to improve retention and engagement</p>
+      </div>
+      <div class="audience-card">
+        <h3>Product Designers</h3>
+        <p>Working on Nostr clients and need research-backed patterns for common UX challenges</p>
+      </div>
+      <div class="audience-card">
+        <h3>Mainstream Developers</h3>
+        <p>Evaluating whether to build on Nostr and need to understand the UX landscape</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="cta-final">
+  <div class="container">
+    <h2>Ready to Improve Your Nostr App's UX?</h2>
+    <a href="{{ "/start/" | relURL }}" class="btn btn-primary btn-large">Get Started</a>
+  </div>
+</section>
+{{ end }}

--- a/themes/nostr-ux/layouts/partials/footer.html
+++ b/themes/nostr-ux/layouts/partials/footer.html
@@ -1,0 +1,29 @@
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-content">
+      <div class="footer-section">
+        <h3>Nostr UX Research Study</h3>
+        <p>Design patterns for building consumer Nostr applications with great UX</p>
+      </div>
+      <div class="footer-section">
+        <h4>Navigation</h4>
+        <ul>
+          {{ range .Site.Menus.main }}
+          <li><a href="{{ .URL | relURL }}">{{ .Name }}</a></li>
+          {{ end }}
+        </ul>
+      </div>
+      <div class="footer-section">
+        <h4>Resources</h4>
+        <ul>
+          <li><a href="https://github.com/shawnyeager/nostr-ux-research">GitHub</a></li>
+          <li><a href="{{ "/resources/methodology/" | relURL }}">Methodology</a></li>
+          <li><a href="{{ "/resources/references/" | relURL }}">References</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>&copy; {{ now.Year }} {{ .Site.Params.author }}. Research and content licensed under CC BY 4.0.</p>
+    </div>
+  </div>
+</footer>

--- a/themes/nostr-ux/layouts/partials/header.html
+++ b/themes/nostr-ux/layouts/partials/header.html
@@ -1,0 +1,26 @@
+<header class="site-header">
+  <div class="container">
+    <div class="header-content">
+      <a href="{{ "/" | relURL }}" class="site-title">{{ .Site.Title }}</a>
+      <nav class="main-nav">
+        {{ range .Site.Menus.main }}
+        <a href="{{ .URL | relURL }}" {{ if $.IsMenuCurrent "main" . }}class="active"{{ end }}>{{ .Name }}</a>
+        {{ end }}
+      </nav>
+      <button class="search-toggle" id="search-toggle" aria-label="Search">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor">
+          <circle cx="8" cy="8" r="6" stroke-width="2"/>
+          <path d="M13 13L18 18" stroke-width="2" stroke-linecap="round"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</header>
+
+<div class="search-overlay" id="search-overlay">
+  <div class="search-container">
+    <input type="search" id="search-input" placeholder="Search patterns, concepts..." autofocus>
+    <div id="search-results"></div>
+  </div>
+  <button class="search-close" id="search-close" aria-label="Close search">×</button>
+</div>

--- a/themes/nostr-ux/static/css/main.css
+++ b/themes/nostr-ux/static/css/main.css
@@ -1,0 +1,685 @@
+/* ===== CSS Variables ===== */
+:root {
+  /* Colors - Clean/Minimal Palette */
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-secondary: #475569;
+  --color-text: #1e293b;
+  --color-text-light: #64748b;
+  --color-bg: #ffffff;
+  --color-bg-alt: #f8fafc;
+  --color-border: #e2e8f0;
+  --color-code-bg: #f1f5f9;
+
+  /* Typography */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace;
+
+  /* Spacing */
+  --space-xs: 0.5rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-2xl: 4rem;
+
+  /* Layout */
+  --container-width: 1200px;
+  --content-width: 800px;
+  --border-radius: 8px;
+
+  /* Transitions */
+  --transition: all 0.2s ease;
+}
+
+/* ===== Reset & Base ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-sans);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+}
+
+/* ===== Typography ===== */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600;
+  line-height: 1.3;
+  margin-bottom: var(--space-md);
+}
+
+h1 { font-size: 2.5rem; }
+h2 { font-size: 2rem; margin-top: var(--space-xl); }
+h3 { font-size: 1.5rem; margin-top: var(--space-lg); }
+h4 { font-size: 1.25rem; margin-top: var(--space-md); }
+
+p {
+  margin-bottom: var(--space-md);
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: var(--transition);
+}
+
+a:hover {
+  color: var(--color-primary-hover);
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background-color: var(--color-code-bg);
+  padding: 0.125rem 0.375rem;
+  border-radius: 3px;
+}
+
+pre {
+  background-color: var(--color-code-bg);
+  padding: var(--space-md);
+  border-radius: var(--border-radius);
+  overflow-x: auto;
+  margin-bottom: var(--space-md);
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* ===== Layout ===== */
+.container {
+  max-width: var(--container-width);
+  margin: 0 auto;
+  padding: 0 var(--space-md);
+}
+
+.content-wrapper {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-xl);
+}
+
+@media (min-width: 1024px) {
+  .content-wrapper {
+    grid-template-columns: 250px 1fr;
+  }
+}
+
+.content {
+  max-width: var(--content-width);
+}
+
+/* ===== Header ===== */
+.site-header {
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-md) 0;
+  position: sticky;
+  top: 0;
+  background-color: var(--color-bg);
+  z-index: 100;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.site-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.main-nav {
+  display: none;
+  gap: var(--space-lg);
+}
+
+@media (min-width: 768px) {
+  .main-nav {
+    display: flex;
+  }
+}
+
+.main-nav a {
+  color: var(--color-text-light);
+  font-weight: 500;
+  transition: var(--transition);
+}
+
+.main-nav a:hover,
+.main-nav a.active {
+  color: var(--color-primary);
+}
+
+.search-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-light);
+  padding: var(--space-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search-toggle:hover {
+  color: var(--color-primary);
+}
+
+/* ===== Footer ===== */
+.site-footer {
+  background-color: var(--color-bg-alt);
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-2xl);
+  padding: var(--space-2xl) 0 var(--space-lg);
+}
+
+.footer-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
+}
+
+@media (min-width: 768px) {
+  .footer-content {
+    grid-template-columns: 2fr 1fr 1fr;
+  }
+}
+
+.footer-section h3,
+.footer-section h4 {
+  font-size: 1rem;
+  margin-bottom: var(--space-sm);
+}
+
+.footer-section ul {
+  list-style: none;
+}
+
+.footer-section ul li {
+  margin-bottom: var(--space-xs);
+}
+
+.footer-section a {
+  color: var(--color-text-light);
+}
+
+.footer-bottom {
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-light);
+  font-size: 0.875rem;
+}
+
+/* ===== Hero Section ===== */
+.hero {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  padding: var(--space-2xl) 0;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  margin-bottom: var(--space-md);
+}
+
+.hero-subtitle {
+  font-size: 1.25rem;
+  margin-bottom: var(--space-xl);
+  opacity: 0.95;
+}
+
+.hero-cta {
+  display: flex;
+  gap: var(--space-md);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ===== Buttons ===== */
+.btn {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--border-radius);
+  font-weight: 500;
+  text-align: center;
+  transition: var(--transition);
+  border: 2px solid transparent;
+}
+
+.btn-primary {
+  background-color: var(--color-primary);
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: var(--color-primary-hover);
+  color: white;
+}
+
+.btn-secondary {
+  background-color: white;
+  color: var(--color-primary);
+  border-color: white;
+}
+
+.btn-secondary:hover {
+  background-color: transparent;
+  color: white;
+  border-color: white;
+}
+
+.btn-large {
+  padding: 1rem 2rem;
+  font-size: 1.125rem;
+}
+
+/* ===== Sections ===== */
+section {
+  padding: var(--space-2xl) 0;
+}
+
+.section-lead {
+  font-size: 1.125rem;
+  color: var(--color-text-light);
+  max-width: 800px;
+  margin: 0 auto var(--space-xl);
+  text-align: center;
+}
+
+.problem-section {
+  background-color: var(--color-bg-alt);
+}
+
+.problem-section h2 {
+  text-align: center;
+  margin-bottom: var(--space-xl);
+}
+
+/* ===== Stats Grid ===== */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--space-lg);
+  margin-bottom: var(--space-xl);
+}
+
+.stat-card {
+  background: white;
+  padding: var(--space-lg);
+  border-radius: var(--border-radius);
+  text-align: center;
+  border: 1px solid var(--color-border);
+}
+
+.stat-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  margin-bottom: var(--space-sm);
+}
+
+.stat-label {
+  color: var(--color-text-light);
+  font-size: 0.875rem;
+}
+
+/* ===== Pattern Cards ===== */
+.pattern-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-lg);
+  margin-bottom: var(--space-xl);
+}
+
+.pattern-card {
+  background: white;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: var(--space-lg);
+  transition: var(--transition);
+}
+
+.pattern-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.pattern-number {
+  display: inline-block;
+  background-color: var(--color-primary);
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: var(--space-sm);
+}
+
+.pattern-card h3 {
+  margin-top: 0;
+  margin-bottom: var(--space-sm);
+}
+
+.pattern-card h3 a {
+  color: var(--color-text);
+}
+
+.pattern-problem,
+.pattern-impact,
+.pattern-solution {
+  font-size: 0.875rem;
+  margin-bottom: var(--space-sm);
+  color: var(--color-text-light);
+}
+
+.pattern-link {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+/* ===== Pattern List ===== */
+.pattern-list-item {
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-lg) 0;
+}
+
+.pattern-list-item:last-child {
+  border-bottom: none;
+}
+
+.pattern-meta {
+  margin-bottom: var(--space-sm);
+}
+
+.meta-item {
+  font-size: 0.875rem;
+  color: var(--color-text-light);
+  margin-bottom: var(--space-xs);
+}
+
+.read-more {
+  display: inline-block;
+  margin-top: var(--space-sm);
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+/* ===== Validation Framework ===== */
+.framework-questions {
+  background-color: var(--color-bg-alt);
+  padding: var(--space-lg);
+  border-radius: var(--border-radius);
+  border-left: 4px solid var(--color-primary);
+  margin-bottom: var(--space-md);
+}
+
+.framework-questions li {
+  margin-bottom: var(--space-sm);
+}
+
+.framework-principle {
+  text-align: center;
+  font-size: 1.125rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+/* ===== Audience Grid ===== */
+.audience-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-lg);
+}
+
+.audience-card {
+  background-color: var(--color-bg-alt);
+  padding: var(--space-lg);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--color-border);
+}
+
+.audience-card h3 {
+  margin-top: 0;
+  color: var(--color-primary);
+}
+
+/* ===== Page Header ===== */
+.page-header {
+  background-color: var(--color-bg-alt);
+  padding: var(--space-xl) 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-xl);
+}
+
+.page-header h1 {
+  margin-bottom: var(--space-sm);
+}
+
+.page-description {
+  font-size: 1.125rem;
+  color: var(--color-text-light);
+}
+
+.pattern-badge {
+  display: inline-block;
+  background-color: var(--color-primary);
+  color: white;
+  padding: 0.375rem 1rem;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: var(--space-sm);
+}
+
+.meta {
+  color: var(--color-text-light);
+  font-size: 0.875rem;
+}
+
+/* ===== Table of Contents ===== */
+.toc {
+  position: sticky;
+  top: 100px;
+  align-self: start;
+}
+
+.toc h3 {
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: var(--space-sm);
+}
+
+.toc ul {
+  list-style: none;
+  font-size: 0.875rem;
+}
+
+.toc li {
+  margin-bottom: var(--space-xs);
+}
+
+.toc a {
+  color: var(--color-text-light);
+}
+
+.toc a:hover {
+  color: var(--color-primary);
+}
+
+/* ===== Page Navigation ===== */
+.page-navigation {
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-xl);
+}
+
+.page-navigation .container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-lg);
+}
+
+.nav-prev,
+.nav-next {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  transition: var(--transition);
+}
+
+.nav-prev:hover,
+.nav-next:hover {
+  border-color: var(--color-primary);
+  background-color: var(--color-bg-alt);
+}
+
+.nav-next {
+  text-align: right;
+}
+
+.nav-label {
+  font-size: 0.875rem;
+  color: var(--color-text-light);
+  margin-bottom: var(--space-xs);
+}
+
+.nav-title {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+/* ===== Search Overlay ===== */
+.search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+}
+
+.search-overlay.active {
+  display: flex;
+}
+
+.search-container {
+  background: white;
+  border-radius: var(--border-radius);
+  width: 90%;
+  max-width: 600px;
+  max-height: 70vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#search-input {
+  width: 100%;
+  padding: var(--space-md);
+  font-size: 1.125rem;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+}
+
+#search-input:focus {
+  outline: none;
+}
+
+#search-results {
+  overflow-y: auto;
+  padding: var(--space-md);
+}
+
+.search-result {
+  padding: var(--space-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.search-result:last-child {
+  border-bottom: none;
+}
+
+.search-result h4 {
+  margin: 0 0 var(--space-xs);
+}
+
+.search-result p {
+  font-size: 0.875rem;
+  color: var(--color-text-light);
+  margin: 0;
+}
+
+.search-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: white;
+  border: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  font-size: 1.5rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ===== CTA Blocks ===== */
+.cta-block {
+  text-align: center;
+  margin-top: var(--space-xl);
+}
+
+.cta-final {
+  background-color: var(--color-bg-alt);
+  text-align: center;
+}
+
+.cta-final h2 {
+  margin-bottom: var(--space-lg);
+}
+
+/* ===== Utility Classes ===== */
+.text-center {
+  text-align: center;
+}
+
+.mt-0 { margin-top: 0; }
+.mb-0 { margin-bottom: 0; }
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+  h1 { font-size: 2rem; }
+  h2 { font-size: 1.75rem; }
+  .hero h1 { font-size: 2rem; }
+  .hero-subtitle { font-size: 1rem; }
+}

--- a/themes/nostr-ux/static/js/search.js
+++ b/themes/nostr-ux/static/js/search.js
@@ -1,0 +1,162 @@
+// Search functionality using Lunr.js
+(function() {
+  const searchToggle = document.getElementById('search-toggle');
+  const searchClose = document.getElementById('search-close');
+  const searchOverlay = document.getElementById('search-overlay');
+  const searchInput = document.getElementById('search-input');
+  const searchResults = document.getElementById('search-results');
+
+  let searchIndex;
+  let searchDocuments;
+
+  // Toggle search overlay
+  if (searchToggle) {
+    searchToggle.addEventListener('click', () => {
+      searchOverlay.classList.add('active');
+      searchInput.focus();
+
+      // Load search index on first open
+      if (!searchIndex) {
+        loadSearchIndex();
+      }
+    });
+  }
+
+  // Close search overlay
+  if (searchClose) {
+    searchClose.addEventListener('click', closeSearch);
+  }
+
+  // Close on overlay click
+  if (searchOverlay) {
+    searchOverlay.addEventListener('click', (e) => {
+      if (e.target === searchOverlay) {
+        closeSearch();
+      }
+    });
+  }
+
+  // Close on Escape key
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && searchOverlay.classList.contains('active')) {
+      closeSearch();
+    }
+  });
+
+  function closeSearch() {
+    searchOverlay.classList.remove('active');
+    searchInput.value = '';
+    searchResults.innerHTML = '';
+  }
+
+  // Load search index
+  async function loadSearchIndex() {
+    try {
+      const response = await fetch('/nostr-ux-research/index.json');
+      searchDocuments = await response.json();
+
+      // Build Lunr index
+      searchIndex = lunr(function() {
+        this.ref('url');
+        this.field('title', { boost: 10 });
+        this.field('content');
+        this.field('tags', { boost: 5 });
+
+        searchDocuments.forEach((doc) => {
+          this.add(doc);
+        });
+      });
+    } catch (error) {
+      console.error('Failed to load search index:', error);
+      searchResults.innerHTML = '<p class="search-error">Search is currently unavailable.</p>';
+    }
+  }
+
+  // Perform search
+  if (searchInput) {
+    searchInput.addEventListener('input', debounce((e) => {
+      const query = e.target.value.trim();
+
+      if (query.length < 2) {
+        searchResults.innerHTML = '';
+        return;
+      }
+
+      if (!searchIndex) {
+        searchResults.innerHTML = '<p>Loading search index...</p>';
+        return;
+      }
+
+      try {
+        const results = searchIndex.search(query);
+
+        if (results.length === 0) {
+          searchResults.innerHTML = '<p class="search-no-results">No results found.</p>';
+          return;
+        }
+
+        const html = results.slice(0, 10).map(result => {
+          const doc = searchDocuments.find(d => d.url === result.ref);
+          if (!doc) return '';
+
+          const excerpt = getExcerpt(doc.content, query);
+
+          return `
+            <div class="search-result">
+              <h4><a href="${doc.url}">${doc.title}</a></h4>
+              <p>${excerpt}</p>
+            </div>
+          `;
+        }).join('');
+
+        searchResults.innerHTML = html;
+      } catch (error) {
+        console.error('Search error:', error);
+        searchResults.innerHTML = '<p class="search-error">Search error occurred.</p>';
+      }
+    }, 300));
+  }
+
+  // Get excerpt around query term
+  function getExcerpt(text, query, maxLength = 200) {
+    const lowerText = text.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+    const index = lowerText.indexOf(lowerQuery);
+
+    if (index === -1) {
+      return text.substring(0, maxLength) + '...';
+    }
+
+    const start = Math.max(0, index - 80);
+    const end = Math.min(text.length, index + maxLength - 80);
+
+    let excerpt = text.substring(start, end);
+
+    if (start > 0) excerpt = '...' + excerpt;
+    if (end < text.length) excerpt = excerpt + '...';
+
+    // Highlight query term
+    const regex = new RegExp(`(${escapeRegex(query)})`, 'gi');
+    excerpt = excerpt.replace(regex, '<strong>$1</strong>');
+
+    return excerpt;
+  }
+
+  // Debounce helper
+  function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        clearTimeout(timeout);
+        func(...args);
+      };
+      clearTimeout(timeout);
+      timeout = setTimeout(later, wait);
+    };
+  }
+
+  // Escape regex special characters
+  function escapeRegex(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+})();

--- a/themes/nostr-ux/theme.toml
+++ b/themes/nostr-ux/theme.toml
@@ -1,0 +1,8 @@
+name = "Nostr UX"
+license = "MIT"
+description = "Clean, minimal theme for Nostr UX Research documentation"
+homepage = "https://github.com/shawnyeager/nostr-ux-research"
+min_version = "0.112.0"
+
+[author]
+  name = "Shawn Yeager"


### PR DESCRIPTION
Created comprehensive Hugo-based website to make the research maximally accessible:

**Site Architecture:**
- Homepage with hero, problem stats, pattern previews, validation framework
- Get Started page with executive overview and quick wins
- Pattern library with auto-generated cards
- Clean/minimal design (mobile-first, Stripe-inspired)
- Search functionality (Lunr.js client-side)
- Plausible.io analytics integration

**Hugo Setup:**
- Custom theme (themes/nostr-ux/)
- Responsive CSS (~600 lines, clean/minimal style)
- Module mounts for existing markdown files
- GitHub Actions workflow for auto-deployment
- Search index generation

**Content Updates:**
- Added YAML front matter to all 6 pattern files
- Created /start/ page with executive overview
- Created pattern library index page
- Updated quick-reference.md with front matter

**Features Implemented:**
- Mobile-responsive design
- Sticky navigation and TOC
- Pattern cards with problem/impact/solution
- Client-side search with keyboard shortcut
- Previous/Next navigation between patterns
- Syntax highlighting for code examples
- Auto-deployment to GitHub Pages

**Documentation:**
- HUGO_SITE.md with complete setup/maintenance guide
- .gitignore for Hugo build outputs

All existing markdown files remain fully readable on GitHub while being processed by Hugo for the website.